### PR TITLE
ci: publish softnpu

### DIFF
--- a/.github/buildomat/jobs/build-and-test.sh
+++ b/.github/buildomat/jobs/build-and-test.sh
@@ -9,6 +9,10 @@
 #:   "/work/release/*",
 #: ]
 #:
+#: [[publish]]
+#: series = "image"
+#: name = "softnpu"
+#: from_output = "/work/release/softnpu"
 
 set -o errexit
 set -o pipefail

--- a/.github/buildomat/jobs/build-and-test.sh
+++ b/.github/buildomat/jobs/build-and-test.sh
@@ -13,6 +13,11 @@
 #: series = "image"
 #: name = "softnpu"
 #: from_output = "/work/release/softnpu"
+#:
+#: [[publish]]
+#: series = "image"
+#: name = "softnpu.sha256.txt"
+#: from_output = "/work/release/softnpu.sha256.txt"
 
 set -o errexit
 set -o pipefail
@@ -33,5 +38,6 @@ for x in debug release
 do
     mkdir -p /work/$x
     cp target/$x/softnpu /work/$x/
+    digest -a sha256 /work/$x/softnpu > /work/$x/softnpu.sha256.txt
 done
 


### PR DESCRIPTION
Let's use the actual publishing functionality so we can use the SHA-based URLs from omicron.