### PR TITLE
Re-export p4rs crate, and use specific dep.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -374,7 +374,8 @@ dependencies = [
 [[package]]
 name = "dof"
 version = "0.1.5"
-source = "git+https://github.com/oxidecomputer/usdt#06ffa81af8a08c1f7e89272f570a9cd26d068854"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e6b21a1211455e82b1245d6e1b024f30606afbb734c114515d40d0e0b34ce81"
 dependencies = [
  "thiserror",
  "zerocopy",
@@ -383,7 +384,8 @@ dependencies = [
 [[package]]
 name = "dtrace-parser"
 version = "0.1.14"
-source = "git+https://github.com/oxidecomputer/usdt#06ffa81af8a08c1f7e89272f570a9cd26d068854"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bed110893a7f9f4ceb072e166354a09f6cb4cc416eec5b5e5e8ee367442d434b"
 dependencies = [
  "pest",
  "pest_derive",
@@ -749,7 +751,7 @@ checksum = "ceedf44fb00f2d1984b0bc98102627ce622e083e49a5bacdb3e514fa4238e267"
 [[package]]
 name = "p4rs"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/p4?branch=main#5d84413c11c745a8debbd70cd05f2c63ae9a7f8d"
+source = "git+https://github.com/oxidecomputer/p4?rev=d59491f86668e15e92f35ffe3f94504ff4241c64#d59491f86668e15e92f35ffe3f94504ff4241c64"
 dependencies = [
  "bitvec",
  "colored",
@@ -1061,14 +1063,13 @@ dependencies = [
 
 [[package]]
 name = "serde_tokenstream"
-version = "0.2.0"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a00ffd23fd882d096f09fcaae2a9de8329a328628e86027e049ee051dc1621f"
+checksum = "797ba1d80299b264f3aac68ab5d12e5825a561749db4df7cd7c8083900c5d4e9"
 dependencies = [
  "proc-macro2",
- "quote",
  "serde",
- "syn 2.0.15",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1226,6 +1227,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1417,9 +1430,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+
+[[package]]
 name = "usdt"
 version = "0.3.5"
-source = "git+https://github.com/oxidecomputer/usdt#06ffa81af8a08c1f7e89272f570a9cd26d068854"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b4c48f9e522b977bbe938a0d7c4d36633d267ba0155aaa253fb57d0531be0fb"
 dependencies = [
  "dtrace-parser",
  "serde",
@@ -1431,20 +1451,22 @@ dependencies = [
 [[package]]
 name = "usdt-attr-macro"
 version = "0.3.5"
-source = "git+https://github.com/oxidecomputer/usdt#06ffa81af8a08c1f7e89272f570a9cd26d068854"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80e6ae4f982ae74dcbaa8eb17baf36ca0d464a3abc8a7172b3bd74c73e9505d6"
 dependencies = [
  "dtrace-parser",
  "proc-macro2",
  "quote",
  "serde_tokenstream",
- "syn 2.0.15",
+ "syn 1.0.109",
  "usdt-impl",
 ]
 
 [[package]]
 name = "usdt-impl"
 version = "0.3.5"
-source = "git+https://github.com/oxidecomputer/usdt#06ffa81af8a08c1f7e89272f570a9cd26d068854"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f53b4ca0b33aae466dc47b30b98adc4f88454928837af8010b6ed02d18474cb1"
 dependencies = [
  "byteorder",
  "dof",
@@ -1454,7 +1476,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "syn 2.0.15",
+ "syn 1.0.109",
  "thiserror",
  "thread-id",
  "version_check",
@@ -1463,13 +1485,14 @@ dependencies = [
 [[package]]
 name = "usdt-macro"
 version = "0.3.5"
-source = "git+https://github.com/oxidecomputer/usdt#06ffa81af8a08c1f7e89272f570a9cd26d068854"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cb093f9653dc91632621c754f9ed4ee25d14e46e0239b6ccaf74a6c0c2788bd"
 dependencies = [
  "dtrace-parser",
  "proc-macro2",
  "quote",
  "serde_tokenstream",
- "syn 2.0.15",
+ "syn 1.0.109",
  "usdt-impl",
 ]
 
@@ -1689,9 +1712,9 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.6.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "332f188cc1bcf1fe1064b8c58d150f497e697f49774aa846f2dc949d9a25f236"
+checksum = "6580539ad917b7c026220c4b3f2c08d52ce54d6ce0dc491e66002e35388fab46"
 dependencies = [
  "byteorder",
  "zerocopy-derive",
@@ -1699,11 +1722,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.3.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6505e6815af7de1746a08f69c69606bb45695a17149517680f3b2149713b19a3"
+checksum = "d498dbd1fd7beb83c86709ae1c33ca50942889473473d287d56ce4770a18edfb"
 dependencies = [
  "proc-macro2",
- "quote",
  "syn 1.0.109",
+ "synstructure",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ dlpi = { git = "https://github.com/oxidecomputer/dlpi-sys", branch = "main" }
 indicatif = "0.17.2"
 libc = "0.2.137"
 libloading = "0.7.3"
-p4rs = { git = "https://github.com/oxidecomputer/p4", branch = "main" }
+p4rs = { git = "https://github.com/oxidecomputer/p4", rev = "d59491f86668e15e92f35ffe3f94504ff4241c64" }
 p9ds = { git = "https://github.com/oxidecomputer/p9fs", branch = "main" }
 p9kp = { git = "https://github.com/oxidecomputer/p9fs", branch = "main" }
 serde = { version = "1.0.147", features = ["derive"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,3 +2,6 @@
 
 pub mod mgmt;
 pub mod p9;
+
+// Re-export p4rs so consumers can rely on matching types
+pub use p4rs;


### PR DESCRIPTION
Downstream consumers (read: propolis) of softnpu utilize the p4rs types in their interactions with this crate.  To ensure that the types match up, p4rs is re-exported from this library, and the dependency locked to a git revision. (As opposed to relying on Cargo.lock, which is useless when built as a dependency.)